### PR TITLE
Use `ComposeC` to shrink class, and `FlipC` to remove `ArgDictV`

### DIFF
--- a/src/Data/Constraint/Extras.hs
+++ b/src/Data/Constraint/Extras.hs
@@ -11,6 +11,7 @@
 module Data.Constraint.Extras where
 
 import Data.Constraint
+import Data.Constraint.Compose
 import Data.Constraint.Forall
 
 -- | Morally, this class is for GADTs whose indices can be finitely enumerated. It provides operations which will
@@ -24,9 +25,13 @@ import Data.Constraint.Forall
 -- want to go quite that far at the time of writing.
 class ArgDict f where
   type ConstraintsFor f (c :: k -> Constraint) :: Constraint
-  type ConstraintsFor' f (c :: k -> Constraint) (g :: k' -> k) :: Constraint
   argDict :: ConstraintsFor f c => f a -> Dict (c a)
-  argDict' :: ConstraintsFor' f c g => f a -> Dict (c (g a))
+
+type ConstraintsFor' f (c :: k -> Constraint) (g :: k' -> k) = ConstraintsFor f (ComposeC c g)
+
+argDict' :: forall f c g a. (ArgDict f, ConstraintsFor' f c g) => f a -> Dict (c (g a))
+argDict' tag = case argDict tag of
+  (Dict :: Dict (ComposeC c g a)) -> Dict
 
 -- | This places a tighter restriction on the kind of f, and so needs to be a separate class.
 class ArgDictV f where

--- a/src/Data/Constraint/Extras/TH.hs
+++ b/src/Data/Constraint/Extras/TH.hs
@@ -24,15 +24,12 @@ deriveArgDict n = do
         Right t -> AppT (VarT c) (AppT (VarT g) t)
       l = length xs
       constraints = foldl AppT (TupleT l) xs
-      constraints' = foldl AppT (TupleT l) xs'
   arity <- tyConArity n
   tyVars <- replicateM (arity - 1) (newName "a")
   let n' = foldr (\v x -> AppT x (VarT v)) (ConT n) tyVars
   [d| instance ArgDict $(pure n') where
         type ConstraintsFor  $(pure n') $(varT c) = $(pure constraints)
-        type ConstraintsFor' $(pure n') $(varT c) $(varT g) = $(pure constraints')
         argDict = $(LamCaseE <$> matches n 'argDict)
-        argDict' = $(LamCaseE <$> matches n 'argDict')
     |]
 
 deriveArgDictV :: Name -> Q [Dec]

--- a/src/Data/Constraint/Extras/TH.hs
+++ b/src/Data/Constraint/Extras/TH.hs
@@ -32,22 +32,8 @@ deriveArgDict n = do
         argDict = $(LamCaseE <$> matches n 'argDict)
     |]
 
-deriveArgDictV :: Name -> Q [Dec]
-deriveArgDictV n = do
-  vs <- gadtIndices n
-  c <- newName "c"
-  g <- newName "g"
-  let xs = flip map vs $ \case
-        Left t -> AppT (AppT (AppT (ConT ''ConstraintsForV) t) (VarT c)) (VarT g)
-        Right v -> AppT (VarT c) $ AppT v (VarT g)
-      l = length xs
-      constraints = foldl AppT (TupleT l) xs
-  ds <- deriveArgDict n
-  d <- [d| instance ArgDictV $(pure $ ConT n) where
-             type ConstraintsForV $(conT n) $(varT c) $(varT g) = $(pure constraints)
-             argDictV = $(LamCaseE <$> matches n 'argDictV)
-       |]
-  return (d ++ ds)
+{-# DEPRECATED deriveArgDictV "Just use 'deriveArgDict'" #-}
+deriveArgDictV = deriveArgDict
 
 matches :: Name -> Name -> Q [Match]
 matches n argDictName = do


### PR DESCRIPTION
Blocked on https://github.com/ekmett/constraints/pull/84 exposing `ComposeC`.