### PR TITLE
WIP: Rewrite the class to fully describe Gadt's phantoms

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@
 NB: This example can be built with `-pgmL markdown-unlit`.
 
 ```haskell
+{-# LANGUAGE DataKinds #-}
 {-# LANGUAGE GADTs #-}
 {-# LANGUAGE KindSignatures #-}
 {-# LANGUAGE PolyKinds #-}

--- a/constraints-extras.cabal
+++ b/constraints-extras.cabal
@@ -26,6 +26,7 @@ library
                   , TemplateHaskell
   build-depends: base >=4.9 && <4.12
                , constraints >= 0.9 && < 0.11
+               , lens
                , template-haskell >=2.11 && <2.14
   hs-source-dirs:  src
   default-language: Haskell2010

--- a/src/Data/Constraint/Extras/TH.hs
+++ b/src/Data/Constraint/Extras/TH.hs
@@ -1,15 +1,14 @@
 {-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE QuasiQuotes #-}
 {-# LANGUAGE TemplateHaskell #-}
+
 module Data.Constraint.Extras.TH (deriveArgDict, deriveArgDictV, gadtIndices) where
 
-import Data.Constraint.Extras
 import Control.Monad
 import Data.Constraint
+import Data.Constraint.Extras
 import Data.Maybe
 import Language.Haskell.TH
-
-import Data.Either
 
 deriveArgDict :: Name -> Q [Dec]
 deriveArgDict n = do
@@ -29,13 +28,14 @@ deriveArgDict n = do
     |]
 
 {-# DEPRECATED deriveArgDictV "Just use 'deriveArgDict'" #-}
+deriveArgDictV :: Name -> Q [Dec]
 deriveArgDictV = deriveArgDict
 
 matches :: Name -> Name -> Q [Match]
 matches n argDictName = do
   x <- newName "x"
   reify n >>= \case
-    TyConI (DataD _ _ _ _ cons _) -> fmap concat $ forM cons $ \case
+    TyConI (DataD _ _ _ _ constrs _) -> fmap concat $ forM constrs $ \case
       GadtC [name] _ _ -> return $
         [Match (RecP name []) (NormalB $ ConE 'Dict) []]
       ForallC _ _ (GadtC [name] bts (AppT _ (VarT b))) -> do
@@ -76,7 +76,7 @@ tyConArity n = reify n >>= return . \case
 
 gadtIndices :: Name -> Q [Either Type Type]
 gadtIndices n = reify n >>= \case
-  TyConI (DataD _ _ _ _ cons _) -> forM cons $ \case
+  TyConI (DataD _ _ _ _ constrs _) -> forM constrs $ \case
     GadtC _ _ (AppT _ typ) -> return $ Right typ
     ForallC _ _ (GadtC _ bts (AppT _ (VarT _))) -> fmap (head . catMaybes) $ forM bts $ \case
       (_, AppT t (VarT _)) -> do


### PR DESCRIPTION
This is strictly more general; for example, it should allow making a "total dmap" where these cursors are the indices.

With this change, the `ArgDict` class itself should really be called `GGeneric` or something. It's now about generically describing the type-constraining effects of a GADT, with constraints being just one use-case.