### PR TITLE
Revert "Disable readme build for ghcjs"

### DIFF
--- a/constraints-extras.cabal
+++ b/constraints-extras.cabal
@@ -31,8 +31,6 @@ library
   default-language: Haskell2010
 
 executable readme
-  if impl(ghcjs)
-    buildable: False
   build-depends: base >=4.9 && <4.12
                , aeson
                , constraints >= 0.9 && < 0.11


### PR DESCRIPTION
This reverts commit 3a85c663a6d46e31b9d5eaacb85e7625c9802d22.

This now buildable on ghcjs with https://github.com/obsidiansystems/rhyolite/blob/e9f74763c18f0f8d0d396dd5c9c2db720bccecbf/default.nix#L101-L104