### PR TITLE
Compatibility with GHC 8.8

### DIFF
--- a/constraints-extras.cabal
+++ b/constraints-extras.cabal
@@ -30,18 +30,18 @@ library
                   , TypeOperators
                   , ConstraintKinds
                   , TemplateHaskell
-  build-depends: base >=4.9 && <4.13
-               , constraints >= 0.9 && < 0.11
-               , template-haskell >=2.11 && <2.15
+  build-depends: base >=4.9 && <4.14
+               , constraints >= 0.9 && < 0.12
+               , template-haskell >=2.11 && <2.16
   hs-source-dirs:  src
   default-language: Haskell2010
 
 executable readme
   if !flag(build-readme)
     buildable: False
-  build-depends: base >=4.9 && <4.13
+  build-depends: base >=4.9 && <4.14
                , aeson
-               , constraints >= 0.9 && < 0.11
+               , constraints >= 0.9 && < 0.12
                , constraints-extras
   main-is: README.lhs
   ghc-options: -Wall -optL -q


### PR DESCRIPTION
Just updating the bounds on the cabal file for compatibility with ghc 8.8, template-haskell, and constraints :)  These revisions could also be done purely on hackage via hackage metadata, I believe.  Things seem to build fine on my machine :)