### PR TITLE
Bump constraints version constraints on readme

### DIFF
--- a/constraints-extras.cabal
+++ b/constraints-extras.cabal
@@ -43,7 +43,7 @@ executable readme
     buildable: False
   build-depends: base >=4.9 && <4.14
                , aeson
-               , constraints >= 0.9 && < 0.12
+               , constraints >= 0.9 && < 0.13
                , constraints-extras
   main-is: README.lhs
   ghc-options: -Wall -optL -q


### PR DESCRIPTION
This version bound breaks builds in nixpkgs.

Readme still builds with constraints 0.12, I tested it.