### PR TITLE
Support GHC 8.10.1 (fixes #29)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -33,6 +33,9 @@ before_cache:
   - rm -rfv $CABALHOME/packages/head.hackage
 jobs:
   include:
+    - compiler: ghc-8.10.1
+      addons: {"apt":{"sources":[{"sourceline":"deb http://ppa.launchpad.net/hvr/ghc/ubuntu xenial main","key_url":"https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x063dab2bdc0b3f9fcebc378bff3aeacef6f88286"}],"packages":["ghc-8.10.1","cabal-install-3.2"]}}
+      os: linux
     - compiler: ghc-8.8.1
       addons: {"apt":{"sources":[{"sourceline":"deb http://ppa.launchpad.net/hvr/ghc/ubuntu xenial main","key_url":"https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x063dab2bdc0b3f9fcebc378bff3aeacef6f88286"}],"packages":["ghc-8.8.1","cabal-install-3.2"]}}
       os: linux

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -4,6 +4,10 @@
 
 * Allow deriving instances with `deriveArgDict` for data and newtype family instances by supplying the name of one of its constructors
 
+## 0.3.0.3 - 2020-06-22
+
+* Update version bounds for GHC 8.10
+
 ## 0.3.0.2 - 2019-09-30
 
 * Update version bounds for GHC 8.8

--- a/constraints-extras.cabal
+++ b/constraints-extras.cabal
@@ -1,5 +1,5 @@
 name: constraints-extras
-version: 0.3.0.2
+version: 0.3.0.3
 synopsis: Utility package for constraints
 description: Convenience functions and TH for working with constraints. See <https://github.com/obsidiansystems/constraints-extras/blob/develop/README.md README.md> for example usage.
 category: Constraints
@@ -13,7 +13,7 @@ copyright: Obsidian Systems LLC
 build-type: Simple
 cabal-version: 2.0
 tested-with:
-  GHC  ==8.0.2 || ==8.2.2 || ==8.4.4 || ==8.6.5 || ==8.8.1
+  GHC  ==8.0.2 || ==8.2.2 || ==8.4.4 || ==8.6.5 || ==8.8.1 || ==8.10.1
 extra-source-files: README.md
                     ChangeLog.md
 
@@ -32,9 +32,9 @@ library
                   , TypeOperators
                   , ConstraintKinds
                   , TemplateHaskell
-  build-depends: base >=4.9 && <4.14
+  build-depends: base >=4.9 && <4.15
                , constraints >= 0.9 && < 0.13
-               , template-haskell >=2.11 && <2.16
+               , template-haskell >=2.11 && <2.17
   hs-source-dirs:  src
   default-language: Haskell2010
 


### PR DESCRIPTION
Bump dependencies for base and template-haskell.

Also bump version, add changelog entry, and regenerate .travis.yml.

Note that template-haskell 2.16.0.0 adds a new constructor to the
'Type' datatype. However, it is not (yet?) used in any place that
constraints-extra cares about. #29 has some further details.