### PR TITLE
Provide ArgDict instances for sums of functors

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,9 +1,12 @@
 # Revision history for constraints-extras
 
+## 0.3.2.0
+
+* Provide `ArgDict` instances for sums of functors.
+
 ## 0.3.1.0
 
 * Allow deriving instances with `deriveArgDict` for data and newtype family instances by supplying the name of one of its constructors
-* Provide `ArgDict` instances for sums of functors.
 * Support GHC 9.0.1
 
 ## 0.3.0.3 - 2020-06-22

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -3,6 +3,7 @@
 ## Unreleased
 
 * Allow deriving instances with `deriveArgDict` for data and newtype family instances by supplying the name of one of its constructors
+* Provide `ArgDict` instances for sums of functors.
 
 ## 0.3.0.3 - 2020-06-22
 

--- a/src/Data/Constraint/Extras.hs
+++ b/src/Data/Constraint/Extras.hs
@@ -77,14 +77,14 @@ class ArgDict (c :: k -> Constraint) (f :: k -> Type) where
   -- > argDict I :: Dict (Show Int)
   argDict :: ConstraintsFor f c => f a -> Dict (c a)
 
--- | @since 0.3.1
+-- | @since 0.3.2.0
 instance (ArgDict c f, ArgDict c g) => ArgDict c (f :+: g) where
   type ConstraintsFor (f :+: g) c = (ConstraintsFor f c, ConstraintsFor g c)
   argDict = \case
     L1 f -> argDict f
     R1 g -> argDict g
 
--- | @since 0.3.1
+-- | @since 0.3.2.0
 instance (ArgDict c f, ArgDict c g) => ArgDict c (Sum f g) where
   type ConstraintsFor (Sum f g) c = (ConstraintsFor f c, ConstraintsFor g c)
   argDict = \case

--- a/src/Data/Constraint/Extras.hs
+++ b/src/Data/Constraint/Extras.hs
@@ -2,6 +2,7 @@
 {-# LANGUAGE ConstraintKinds #-}
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE PolyKinds #-}
 {-# LANGUAGE RankNTypes #-}
@@ -51,7 +52,9 @@ import Data.Constraint
 import Data.Constraint.Compose
 import Data.Constraint.Flip
 import Data.Constraint.Forall
+import Data.Functor.Sum (Sum(..))
 import Data.Kind
+import GHC.Generics ((:+:)(..))
 
 -- | Morally, this class is for GADTs whose indices can be finitely
 -- enumerated. An @'ArgDict' c f@ instance allows us to do two things:
@@ -73,6 +76,20 @@ class ArgDict (c :: k -> Constraint) (f :: k -> Type) where
   --
   -- > argDict I :: Dict (Show Int)
   argDict :: ConstraintsFor f c => f a -> Dict (c a)
+
+-- | @since 0.3.1
+instance (ArgDict c f, ArgDict c g) => ArgDict c (f :+: g) where
+  type ConstraintsFor (f :+: g) c = (ConstraintsFor f c, ConstraintsFor g c)
+  argDict = \case
+    L1 f -> argDict f
+    R1 g -> argDict g
+
+-- | @since 0.3.1
+instance (ArgDict c f, ArgDict c g) => ArgDict c (Sum f g) where
+  type ConstraintsFor (Sum f g) c = (ConstraintsFor f c, ConstraintsFor g c)
+  argDict = \case
+    InL f -> argDict f
+    InR g -> argDict g
 
 -- | \"Primed\" variants (@ConstraintsFor'@, 'argDict'', 'Has'',
 -- 'has'', &c.) use the 'ArgDict' instance on @f@ to apply constraints


### PR DESCRIPTION
I was surprised that I couldn't do the same for products of functors but it makes sense if you think about it.

Note the `@since` comments - if this isn't going to lead to an imminent release, or the version number is going to be wrong, let me know and I'll fix them.