### PR TITLE
Support GHC 9.2

### DIFF
--- a/.github/workflows/haskell.yml
+++ b/.github/workflows/haskell.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        ghc: ['8.4.4', '8.6.5', '8.8.4', '9.0.1']
+        ghc: ['8.4.4', '8.6.5', '8.8.4', '9.0.1', '9.2.1']
         os: ['ubuntu-latest', 'macos-latest']
     steps:
     - uses: actions/checkout@v2

--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ Example usage:
 > {-# LANGUAGE TemplateHaskell #-}
 > {-# LANGUAGE TypeApplications  #-}
 > {-# LANGUAGE TypeFamilies #-}
+> {-# LANGUAGE FlexibleContexts #-}
 > {-# LANGUAGE FlexibleInstances #-}
 > {-# LANGUAGE MultiParamTypeClasses #-}
 > {-# LANGUAGE UndecidableInstances #-}

--- a/constraints-extras.cabal
+++ b/constraints-extras.cabal
@@ -13,7 +13,7 @@ copyright: Obsidian Systems LLC
 build-type: Simple
 cabal-version: 2.0
 tested-with:
-  GHC  ==8.0.2 || ==8.2.2 || ==8.4.4 || ==8.6.5 || ==8.8.1 || ==8.10.1 || ==9.0.1
+  GHC  ==8.0.2 || ==8.2.2 || ==8.4.4 || ==8.6.5 || ==8.8.1 || ==8.10.1 || ==9.0.1 || ==9.2.1
 extra-source-files: README.md
                     ChangeLog.md
 

--- a/constraints-extras.cabal
+++ b/constraints-extras.cabal
@@ -32,9 +32,9 @@ library
                   , TypeOperators
                   , ConstraintKinds
                   , TemplateHaskell
-  build-depends: base >=4.9 && <4.16
+  build-depends: base >=4.9 && <4.17
                , constraints >= 0.9 && < 0.14
-               , template-haskell >=2.11 && <2.18
+               , template-haskell >=2.11 && <2.19
   hs-source-dirs:  src
   default-language: Haskell2010
 

--- a/src/Data/Constraint/Extras/TH.hs
+++ b/src/Data/Constraint/Extras/TH.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE CPP #-}
 {-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE QuasiQuotes #-}
 {-# LANGUAGE TemplateHaskell #-}
@@ -52,10 +53,18 @@ matches c constrs argDictName = do
                   Nothing -> WildP : rest done
                   Just _ -> VarP v : rest True
               pat = foldr patf (const []) ps False
-          in [Match (ConP name pat) (NormalB $ AppE (VarE argDictName) (VarE v)) []]
+          in [Match (conPCompat name pat) (NormalB $ AppE (VarE argDictName) (VarE v)) []]
     ForallC _ _ (GadtC [name] _ _) -> return $
       [Match (RecP name []) (NormalB $ ConE 'Dict) []]
     a -> error $ "deriveArgDict matches: Unmatched 'Dec': " ++ show a
+
+conPCompat :: Name -> [Pat] -> Pat
+conPCompat name =
+  ConP
+    name
+#if MIN_VERSION_template_haskell(2, 18, 0)
+    []
+#endif
 
 kindArity :: Kind -> Int
 kindArity = \case


### PR DESCRIPTION
This PR allows `constraint-extras` to build with GHC 9.2.1.

Changes
- Relax dependency bounds
- https://gitlab.haskell.org/ghc/ghc/-/wikis/migration/9.2#template-haskell-218
- https://gitlab.haskell.org/ghc/ghc/-/wikis/migration/9.2#undecidableinstances-no-longer-implies-flexiblecontexts-in-instance-declarations