### PR TITLE
bump base and template-haskell upper bounds for ghc 9.4.1

### DIFF
--- a/constraints-extras.cabal
+++ b/constraints-extras.cabal
@@ -32,9 +32,9 @@ library
                   , TypeOperators
                   , ConstraintKinds
                   , TemplateHaskell
-  build-depends: base >=4.9 && <4.17
+  build-depends: base >=4.9 && <4.18
                , constraints >= 0.9 && < 0.14
-               , template-haskell >=2.11 && <2.19
+               , template-haskell >=2.11 && <2.20
   hs-source-dirs:  src
   default-language: Haskell2010
 


### PR DESCRIPTION
This builds with

```
cabal build -w ghc-9.4.1 --allow-newer=type-equality:base,hashable:base,hashable:ghc-bignum
```