### PR TITLE
Fix GitHub actions

### DIFF
--- a/.github/workflows/haskell.yml
+++ b/.github/workflows/haskell.yml
@@ -12,7 +12,8 @@ jobs:
         os: ['ubuntu-latest', 'macos-latest']
     steps:
     - uses: actions/checkout@v2
-    - uses: actions/setup-haskell@v1
+    - name: Setup Haskell
+      uses: haskell/actions/setup@v2
       with:
         ghc-version: ${{ matrix.ghc }}
         cabal-version: '3.0'


### PR DESCRIPTION
Recent CI runs have [been failing](https://github.com/obsidiansystems/constraints-extras/actions/runs/2829863085/jobs/4641462426#step:3:10) with `Error: All install methods for ghc 9.0.1 failed`.

[`actions/setup-haskell`](https://github.com/actions/setup-haskell) has been archived and replaced by [`haskell/actions/setup`](https://github.com/haskell/actions) as a maintained fork.
