### PR TITLE
Make `deriveHas` the recommended TH function to use

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,5 +1,9 @@
 # Revision history for constraints-extras
 
+## Unreleased (minor)
+
+* `Data.Constraint.Extras.deriveHas` is now the TH function you should use to derive `Has` instances. `deriveArgDict` remains as a deprecated alias for `deriveHas`.
+
 ## 0.4.0.2
 
 * Support GHC 9.12

--- a/README.md
+++ b/README.md
@@ -30,25 +30,25 @@ Example usage:
 >   A_a :: A Int
 >   A_b :: Int -> A ()
 >
-> deriveArgDict ''A
+> deriveHas ''A
 >
 > data B :: * -> * where
 >   B_a :: A a -> A a -> B a
 >   B_x :: Int -> B Int
 >
-> deriveArgDict ''B
+> deriveHas ''B
 >
 > data V :: (* -> *) -> * where
 >   V_a :: A Int -> V A
 >
-> deriveArgDict ''V
+> deriveHas ''V
 >
 > data family Fam a :: * -> *
 > data instance Fam () :: * -> * where
 >   FI :: Fam () Int
 >   FB :: Fam () Bool
 >
-> deriveArgDict 'FI
+> deriveHas 'FI
 > -- this derives an instance Has c (Fam ()) by looking up the associated data instance.
 >
 > data DSum k f = forall a. DSum (k a) (f a)

--- a/src/Data/Constraint/Extras.hs
+++ b/src/Data/Constraint/Extras.hs
@@ -23,7 +23,7 @@
 -- >   B :: Tag Bool
 -- > deriving instance Show (Tag a)
 -- >
--- > $(deriveArgDict ''Tag)
+-- > $(deriveHas ''Tag)
 --
 -- The constructors of @Tag@ mean that a type variable @a@ in @Tag a@
 -- must come from the set { @Int@, @Bool@ }. We call this the "set of

--- a/src/Data/Constraint/Extras/TH.hs
+++ b/src/Data/Constraint/Extras/TH.hs
@@ -3,7 +3,12 @@
 {-# LANGUAGE QuasiQuotes #-}
 {-# LANGUAGE TemplateHaskell #-}
 
-module Data.Constraint.Extras.TH (deriveArgDict, deriveArgDictV, gadtIndices) where
+module Data.Constraint.Extras.TH
+  ( deriveHas
+  , deriveArgDict
+  , deriveArgDictV
+  , gadtIndices
+  ) where
 
 import Data.Constraint
 import Data.Constraint.Extras
@@ -11,8 +16,8 @@ import Data.Maybe
 import Control.Monad
 import Language.Haskell.TH
 
-deriveArgDict :: Name -> Q [Dec]
-deriveArgDict n = do
+deriveHas :: Name -> Q[Dec]
+deriveHas n = do
   (typeHead, constrs) <- getDeclInfo n
   c <- newName "c"
   ts <- gadtIndices c constrs
@@ -25,7 +30,11 @@ deriveArgDict n = do
       [ ValD (VarP 'argDict) (NormalB (LamCaseE ms)) [] ]
     ]
 
-{-# DEPRECATED deriveArgDictV "Just use 'deriveArgDict'" #-}
+{-# DEPRECATED deriveArgDict "Just use 'deriveHas'" #-}
+deriveArgDict :: Name -> Q [Dec]
+deriveArgDict = deriveHas
+
+{-# DEPRECATED deriveArgDictV "Just use 'deriveHas'" #-}
 deriveArgDictV :: Name -> Q [Dec]
 deriveArgDictV = deriveArgDict
 
@@ -55,7 +64,7 @@ matches c constrs argDictName = do
           in [Match (conPCompat name pat) (NormalB $ AppE (VarE argDictName) (VarE v)) []]
     ForallC _ _ (GadtC [name] _ _) -> return $
       [Match (RecP name []) (NormalB $ ConE 'Dict) []]
-    a -> error $ "deriveArgDict matches: Unmatched 'Dec': " ++ show a
+    a -> error $ "deriveHas matches: Unmatched 'Dec': " ++ show a
 
 conPCompat :: Name -> [Pat] -> Pat
 conPCompat name =


### PR DESCRIPTION
It seemed weird to me to use `deriveArgDict` when `class ArgDict` no longer exists.