### PR TITLE
Buildable with 9.14

### DIFF
--- a/constraints-extras.cabal
+++ b/constraints-extras.cabal
@@ -14,7 +14,7 @@ build-type: Simple
 cabal-version: 2.0
 tested-with:
   GHC ==8.6.5 || ==8.8.4 || ==8.10.7
-   || ==9.0.2 || ==9.2.8 || ==9.4.8 || ==9.6.6 || ==9.8.4 || ==9.10.1 || ==9.12.1
+   || ==9.0.2 || ==9.2.8 || ==9.4.8 || ==9.6.6 || ==9.8.4 || ==9.10.1 || ==9.12.1 || ==9.14.1
 extra-doc-files: ChangeLog.md
 extra-source-files: README.md
 
@@ -35,24 +35,23 @@ library
                   , TemplateHaskell
   build-depends: base >=4.9 && <4.23
                , constraints >= 0.9 && < 0.15
-               , template-haskell >=2.11 && <2.24
+               , template-haskell >=2.11 && <2.25
 
   hs-source-dirs:  src
   default-language: Haskell2010
-
-  -- This is needed to get around a bug/misfeature in the cabal solver which is choosing an
-  -- old version of aeson (0.9.*) for some reason.
-  if impl (ghc >= 9.12)
-    build-depends: aeson >= 2
-
 
 executable readme
   if !flag(build-readme)
     buildable: False
   build-depends: base
-               , aeson
                , constraints
                , constraints-extras
+  -- This is needed to get around a bug/misfeature in the cabal solver which is choosing an
+  -- old version of aeson (0.9.*) for some reason.
+  if impl (ghc >= 9.12)
+    build-depends: aeson >= 2
+  else
+    build-depends: aeson
   main-is: README.lhs
   ghc-options: -Wall -optL -q
   default-language: Haskell2010


### PR DESCRIPTION
Also moves aeson into readme. I tested on a range of ghc from 8.10 to 9.14, didn't hit anything breaking.